### PR TITLE
Fixes #6. 

### DIFF
--- a/app/Card.php
+++ b/app/Card.php
@@ -102,9 +102,9 @@ class Card extends Model
     public function getSubstituteRulesAttribute() 
     {
     	$name = preg_quote($this->name, '/');
-    	$pattern = '/\b' . preg_replace('/\s+/u', '\s+', $name)  . '\b/u';
+    	$pattern = '/(\b|^|\W)' . preg_replace('/\s+/u', '\s+', $name)  . '(\b|$|\W)/u';
 
-    	$substitute_rules = preg_replace($pattern, '@@@', $this->rules);
+    	$substitute_rules = preg_replace($pattern, '\1@@@\2', $this->rules);
 
     	// Remove reminder text
     	return preg_replace('/^\(.*?\)\n/um', '', $substitute_rules);

--- a/routes/console.php
+++ b/routes/console.php
@@ -221,6 +221,30 @@ Artisan::command('remove-bad-suggestions', function () {
 
 })->describe('Removes suggestions that no longer pass inferior-superior check');
 
+Artisan::command('recreate-substitute-rules', function () {
+
+	$this->comment("Updating cards...");
+	$count = 0;
+
+	$cards = Card::all();
+	$bar = $this->output->createProgressBar(count($cards));
+
+	foreach ($cards as $card) {
+
+		$bar->advance();
+		$new_rules = $card->substituteRules;
+
+		if ($new_rules !== $card->substituted_rules) {
+			$card->substituted_rules = $new_rules;
+
+			$card->save();
+			$count++;
+		}
+	}
+	$bar->finish();
+	$this->comment("Updated " . $count . " cards with new rule substitutions.");
+
+})->describe('Re-creates substitued rules for existing cards.');
 
 Artisan::command('create-obsoletes', function () {
 


### PR DESCRIPTION
Changed rule substitution regex to match wider range of delimeters on both sides of card name. Added 'recreate-substitute-rules' artisan command to update existing rule substitutions.