### PR TITLE
Fix candidate for #8. 'load-scryfall' now looks for cards with same s…

### DIFF
--- a/database/migrations/2019_10_27_210252_index_scryfall_api.php
+++ b/database/migrations/2019_10_27_210252_index_scryfall_api.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class IndexScryfallApi extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('cards', function (Blueprint $table) {
+            $table->index('scryfall_api');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('cards', function (Blueprint $table) {
+            $table->dropIndex('cards_scryfall_api_index');
+        });
+    }
+}


### PR DESCRIPTION
Fix candidate for #8. 'load-scryfall' now looks for cards with same scryfall_api to find previously spoiled cards with different name. 'remove-old-spoilers' Removes existing duplicates from database, also migrating obsoletion and vote data to newest entry (sorted by id). Orphaned functional reprints are also cleared. Created database index for scryfall_api column for faster searching. 

After pulling commands should be run to update:
php artisan migrate
php artisan remove-old-spoilers